### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ or plug with <a href="https://github.com/imjp94/gd-plug">gd-plug</a>:
 plug("MakovWait/godot-script-tabs")
 ```
 
+Shortcuts
+---------
+- Switch to next tab: <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd>
+- Switch to previous tab: <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd>
+- Switch to tab by index: <kbd>Cmd</kbd> + <kbd>0-9</kbd>
+
+
 About
 -----------
 

--- a/addons/script-tabs/plugin.gd
+++ b/addons/script-tabs/plugin.gd
@@ -41,6 +41,11 @@ func _enter_tree() -> void:
 		if HIDE_NATIVE_LIST:
 			_scripts_item_list.get_parent().visible = false
 		_scripts_item_list.property_list_changed.connect(_on_item_list_property_list_changed)
+
+		if _scripts_item_list.get_selected_items().size() > 0:
+			_last_tab_selected = _scripts_item_list.get_selected_items()[0] 
+		else:
+			_last_tab_selected = -1
 	_update_tabs()
 
 
@@ -123,6 +128,25 @@ func _simulate_item_clicked(tab_idx, mouse_idx):
 				_scripts_item_list.get_local_mouse_position(),
 				mouse_idx
 			)
+
+
+func _unhandled_key_input(event):
+	if not _scripts_item_list:
+		return
+		
+	event = event as InputEventKey
+
+	if Input.is_key_pressed(KEY_META):
+		if Input.is_key_pressed(KEY_SHIFT):
+			if not event.is_pressed() and event.keycode == KEY_BRACKETRIGHT:
+				var tabIdx = (max(0,_last_tab_selected) + 1) % _scripts_item_list.item_count
+				_on_tab_selected(tabIdx)
+			elif not event.is_pressed() and event.keycode == KEY_BRACKETLEFT:
+				var tabIdx = ((max(0,_last_tab_selected) - 1) + _scripts_item_list.item_count) % _scripts_item_list.item_count
+				_on_tab_selected(tabIdx)
+		elif not event.is_pressed() and event.keycode >= KEY_0 and event.keycode <= KEY_9:
+			var tabIdx = event.keycode - 49
+			_on_tab_selected(tabIdx)
 
 
 func _update_tabs():


### PR DESCRIPTION
Provides shortcuts that enable the user to toggle between tabs.

Also would have liked to properly map the shortcuts into settings but seems that's still an existing open issue: https://github.com/godotengine/godot-proposals/issues/2024. 
# Testing

Tested on MacOS. Not 100% sure whether `KEY_META` maps properly on Windows or not, so if anyone could test this on windows that would be great.



https://github.com/MakovWait/godot-script-tabs/assets/24768276/af1de579-6781-41f2-9203-01afe55fb852

